### PR TITLE
fix: Suppress multiple requests to OpenAI after clicking the ExportButton

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -99,6 +99,7 @@ function ExportButton({ setHtml }: { setHtml: (html: string) => void }) {
       }}
       className="fixed bottom-4 right-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded ="
       style={{ zIndex: 1000 }}
+      disabled={loading}
     >
       {loading ? (
         <div className="flex justify-center items-center ">


### PR DESCRIPTION
This proposal is a simplified method, but suppresses duplicate requests to OpenAI after the ExportButton is clicked, while the spinner is still spinning.
This prevents users from accidentally clicking the button too many times, resulting in excessive requests.

I think this is a great demo. Thank you I appreciate it.