### PR TITLE
Adding one-click deploy button for RepoCloud.io to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+## ⚡One-Click Deployment
+
+[![Deploy to RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/?app_id=281)


### PR DESCRIPTION
Adding button enabling community access to deploy template for self-hosting on RepoCloud.io with one click.